### PR TITLE
Adjust camera FOV and yaw for complete FOV of both cameras

### DIFF
--- a/src/gazebo/launch/robot_env.sdf
+++ b/src/gazebo/launch/robot_env.sdf
@@ -330,11 +330,11 @@
 
             <!-- Frame for the simulated depth camera -->
             <frame name="sim_depth_camera_1_frame" attached_to='chassis'>
-                <pose>0.5 0.2 0.5 0 0 0.383</pose>
+                <pose>0.5 0 0.5 0 0 0.7592182246</pose> <!-- Where did the 0.2 come from in the second number? Causes a gap between the two cameras.-->
             </frame>
 
             <frame name="sim_depth_camera_2_frame" attached_to='chassis'>
-                <pose>0.5 -0.2 0.5 0 0 -0.383</pose>
+                <pose>0.5 0 0.5 0 0 -0.7592182246</pose> <!-- Where did the -0.2 come from in the second number? Causes a gap between the two cameras.-->
             </frame>
 
             <!-- <frame name="sim_depth_camera_optical_frame" attached_to='sim_depth_camera_frame'>
@@ -392,7 +392,7 @@
                     <pose relative_to="sim_depth_camera_1_frame">0 0 0 0 0 0</pose>
                     <update_rate>30</update_rate>
                     <camera name="color_camera">
-                        <horizontal_fov>0.9686</horizontal_fov>
+                        <horizontal_fov>1.51843645</horizontal_fov>
                         <image>
                             <width>320</width>
                             <height>240</height>
@@ -439,7 +439,7 @@
                     <pose relative_to="sim_depth_camera_2_frame">0 0 0 0 0 0</pose>
                     <update_rate>30</update_rate>
                     <camera name="color_camera">
-                        <horizontal_fov>0.9686</horizontal_fov>
+                        <horizontal_fov>1.51843645</horizontal_fov>
                         <image>
                             <width>320</width>
                             <height>240</height>

--- a/watod-config.sh
+++ b/watod-config.sh
@@ -38,4 +38,4 @@ ACTIVE_MODULES="robot gazebo vis_tools"
 
 ## Platform in which to build the docker images with. 
 ## Either arm64 (apple silicon, raspberry pi) or amd64 (most computers)
-PLATFORM="amd64"
+PLATFORM="arm64"

--- a/watod-config.sh
+++ b/watod-config.sh
@@ -38,4 +38,4 @@ ACTIVE_MODULES="robot gazebo vis_tools"
 
 ## Platform in which to build the docker images with. 
 ## Either arm64 (apple silicon, raspberry pi) or amd64 (most computers)
-PLATFORM="arm64"
+PLATFORM="amd64"


### PR DESCRIPTION
This Pull Request adjusts the horizontal FOV of both depth cameras to 87 degrees and changes the angle position to a calculated angle to ensure maximum FOV for the robot without overlap or gaps between the two cameras.

I also removed the 0.2 and -0.2 values that were adding an extra gap. This gap caused a gap in the FOV which was removed once the two values were set to 0.